### PR TITLE
Switch mission badgets

### DIFF
--- a/src/components/Mission.js
+++ b/src/components/Mission.js
@@ -14,7 +14,7 @@ const Mission = (props) => {
       <th>{name}</th>
       <td>{description}</td>
       <td className="button-container">
-        <Button className="member-button" variant="secondary">NOT A MEMBER</Button>
+        <Button className="member-button" variant={reserved ? 'primary' : 'secondary'}>{ reserved ? 'Active Member' : 'NOT A MEMBER' }</Button>
       </td>
       <td className="button-container">
         <Button className="join-mission-button" variant="outline-secondary" onClick={() => (reserved ? dispatch(leaveMission(id)) : dispatch(joinMission(id)))}>{ reserved ? 'LEAVE MISSION' : 'JOIN MISSION' }</Button>


### PR DESCRIPTION
Missions that the user has joined already show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button.